### PR TITLE
Reduce hlint hints

### DIFF
--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
-import           Control.Monad.Primitive 
+import           Control.Monad.Primitive
 import           Control.Monad
 import           Foreign.C.Types
 import           Foreign.Ptr
@@ -53,7 +53,7 @@ theBench = do
         inBufConv = VG.fromList $ take size $ concat $ repeat [0 .. 255]
 
         duplicate :: [a] -> [a]
-        duplicate = concat . map func 
+        duplicate = concatMap func
             where func x = [x, x]
 
         coeffs2 :: VS.Vector Float

--- a/expts/Benchmark.hs
+++ b/expts/Benchmark.hs
@@ -204,7 +204,7 @@ theBench = do
         inBufConv = VG.fromList $ take size $ concat $ repeat [0 .. 255]
 
         duplicate :: [a] -> [a]
-        duplicate = concat . map func 
+        duplicate = concatMap func
             where func x = [x, x]
 
         coeffs2 :: VS.Vector Float
@@ -343,7 +343,7 @@ theTest = quickCheck $ conjoin [propFiltersComplex]
         where
         eqDelta' x y = magnitude (x - y) < 0.01
     duplicate :: [a] -> [a]
-    duplicate = concat . map func 
+    duplicate = concatMap func
         where func x = [x, x]
 
 main = theBench

--- a/expts/Benchmark.hs
+++ b/expts/Benchmark.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE MultiParamTypeClasses, FlexibleInstances, ScopedTypeVariables, BangPatterns, RecordWildCards #-}
+{-# LANGUAGE MultiParamTypeClasses, FlexibleInstances, ScopedTypeVariables, RecordWildCards #-}
 
 import           Control.Monad.Primitive 
 import           Control.Monad

--- a/expts/Benchmark.hs
+++ b/expts/Benchmark.hs
@@ -261,12 +261,12 @@ theTest = quickCheck $ conjoin [propFiltersComplex]
 
         r1 <- run $ getResult num $ filterHighLevel       num vCoeffs     vInput
 
-        assert $ and $ map (r1 `eqDelta`) [r1]
     propFiltersComplex = forAll sizes $ \size -> 
                              forAll (vectorOf size (choose (-10, 10))) $ \inBufR -> 
                                  forAll (vectorOf size (choose (-10, 10))) $ \inBufI -> 
                                      forAll numCoeffs $ \numCoeffs -> 
                                          forAll (vectorOf numCoeffs (choose (-10, 10))) $ \coeffs -> 
+        assert $ all (r1 `eqDelta`) [r1]
                                              testFiltersComplex size numCoeffs coeffs $ zipWith (:+) inBufR inBufI
     testFiltersComplex :: Int -> Int -> [Float] -> [Complex Float] -> Property
     testFiltersComplex size numCoeffs coeffs inBuf = monadicIO $ do
@@ -278,12 +278,12 @@ theTest = quickCheck $ conjoin [propFiltersComplex]
 
         r1 <- run $ getResult num $ filterHighLevel       num vCoeffs     vInput
 
-        assert $ and $ map (r1 `eqDeltaC`) [r1]
     propDecimationReal = forAll sizes $ \size -> 
                              forAll (vectorOf size (choose (-10, 10))) $ \inBuf -> 
                                  forAll numCoeffs $ \numCoeffs -> 
                                      forAll (vectorOf numCoeffs (choose (-10, 10))) $ \coeffs -> 
                                         forAll factors $ \factor -> 
+        assert $ all (r1 `eqDeltaC`) [r1]
                                              testDecimationReal size numCoeffs factor coeffs inBuf
     testDecimationReal :: Int -> Int -> Int -> [Float] -> [Float] -> Property
     testDecimationReal size numCoeffs factor coeffs inBuf = monadicIO $ do
@@ -294,13 +294,13 @@ theTest = quickCheck $ conjoin [propFiltersComplex]
 
         r1 <- run $ getResult num $ decimateHighLevel       num factor vCoeffs     vInput
 
-        assert $ and $ map (r1 `eqDelta`) [r1]
     propDecimationComplex = forAll sizes $ \size -> 
                                 forAll (vectorOf size (choose (-10, 10))) $ \inBufR -> 
                                     forAll (vectorOf size (choose (-10, 10))) $ \inBufI -> 
                                         forAll numCoeffs $ \numCoeffs -> 
                                             forAll (vectorOf numCoeffs (choose (-10, 10))) $ \coeffs -> 
                                                 forAll factors $ \factor -> 
+        assert $ all (r1 `eqDelta`) [r1]
                                                     testDecimationComplex size numCoeffs factor coeffs $ zipWith (:+) inBufR inBufI
     testDecimationComplex :: Int -> Int -> Int -> [Float] -> [Complex Float] -> Property
     testDecimationComplex size numCoeffs factor coeffs inBuf = monadicIO $ do
@@ -312,13 +312,13 @@ theTest = quickCheck $ conjoin [propFiltersComplex]
 
         r1 <- run $ getResult num $ decimateHighLevel       num factor vCoeffs     vInput
 
-        assert $ and $ map (r1 `eqDeltaC`) [r1]
     propResamplingReal = forAll sizes $ \size -> 
                              forAll (vectorOf size (choose (-10, 10))) $ \inBuf -> 
                                  forAll numCoeffs $ \numCoeffs -> 
                                      forAll (vectorOf numCoeffs (choose (-10, 10))) $ \coeffs -> 
                                         forAll (elements $ tail factors') $ \decimation -> 
                                             forAll (elements $ filter (< decimation) factors') $ \interpolation -> 
+        assert $ all (r1 `eqDeltaC`) [r1]
                                                  testResamplingReal size numCoeffs interpolation decimation coeffs inBuf
     testResamplingReal :: Int -> Int -> Int -> Int -> [Float] -> [Float] -> Property
     testResamplingReal size numCoeffs interpolation decimation coeffs inBuf = monadicIO $ do
@@ -329,17 +329,17 @@ theTest = quickCheck $ conjoin [propFiltersComplex]
 
         r1 <- run $ getResult num $ resampleHighLevel       num interpolation decimation 0 vCoeffs vInput
 
-        assert $ and $ map (r1 `eqDelta`) [r1]
+        assert $ all (r1 `eqDelta`) [r1]
     getResult :: (VSM.Storable a) => Int -> (VS.MVector RealWorld a -> IO b) -> IO [a]
     getResult size func = do
         outBuf <- VGM.new size
         func outBuf
         out :: VS.Vector a <- VG.freeze outBuf
         return $ VG.toList out
-    eqDelta x y = and $ map (uncurry eqDelta') $ zip x y
+    eqDelta x y = all (uncurry eqDelta') $ zip x y
         where
         eqDelta' x y = abs (x - y) < 0.01
-    eqDeltaC x y = and $ map (uncurry eqDelta') $ zip x y
+    eqDeltaC x y = all (uncurry eqDelta') $ zip x y
         where
         eqDelta' x y = magnitude (x - y) < 0.01
     duplicate :: [a] -> [a]

--- a/hs_sources/SDR/Filter.hs
+++ b/hs_sources/SDR/Filter.hs
@@ -144,7 +144,7 @@ data Resampler m v vm a = forall dat. Resampler {
 }
 
 duplicate :: [a] -> [a]
-duplicate = concat . map func 
+duplicate = concatCap func
     where func x = [x, x]
 
 {-# INLINE haskellFilter #-}

--- a/hs_sources/SDR/Filter.hs
+++ b/hs_sources/SDR/Filter.hs
@@ -158,7 +158,7 @@ haskellFilter coeffs = do
     let filterOne   = filterHighLevel      vCoeffs
         filterCross = filterCrossHighLevel vCoeffs
         numCoeffsF  = length coeffs
-    return $ Filter {..}
+    return Filter {..}
 
 mkFilter :: Int
          -> FilterRR
@@ -172,7 +172,7 @@ mkFilter sizeMultiple filterFunc coeffs = do
     evaluate vCoeffs
     let filterOne   = filterFunc           vCoeffs
         filterCross = filterCrossHighLevel vCoeffs
-    return $ Filter {..}
+    return Filter {..}
 
 -- | Returns a fast Filter data structure implemented in C. For filtering real data with real coefficients.
 fastFilterCR :: [Float]                                   -- ^ The filter coefficients
@@ -208,7 +208,7 @@ mkFilterC sizeMultiple filterFunc coeffs = do
     evaluate vCoeffs
     let filterOne   = filterFunc           vCoeffs
         filterCross = filterCrossHighLevel vCoeffs2
-    return $ Filter {..}
+    return Filter {..}
 
 -- | Returns a fast Filter data structure implemented in C For filtering complex data with real coefficients.
 fastFilterCC :: [Float]                                             -- ^ The filter coefficients
@@ -242,7 +242,7 @@ mkFilterSymR filterFunc coeffs = do
     let filterOne   = filterFunc          vCoeffs
         filterCross = filterCrossHighLevel vCoeffs2
         numCoeffsF  = length coeffs * 2
-    return $ Filter {..}
+    return Filter {..}
 
 -- | Returns a fast Filter data structure implemented in C using SSE instructions. For filtering real data with real coefficients. For filters with symmetric coefficients, i.e. 'linear phase'. Coefficient length must be a multiple of 4.
 fastFilterSymSSER :: [Float]                                   -- ^ The first half of the filter coefficients
@@ -287,7 +287,7 @@ mkDecimator sizeMultiple filterFunc decimationD coeffs = do
     evaluate vCoeffs
     let decimateOne   = filterFunc             decimationD vCoeffs
         decimateCross = decimateCrossHighLevel decimationD vCoeffs
-    return $ Decimator {..}
+    return Decimator {..}
 
 -- | Returns a fast Decimator data structure implemented in C. For decimating real data with real coefficients.
 fastDecimatorCR :: Int                                          -- ^ The decimation factor
@@ -328,7 +328,7 @@ mkDecimatorC sizeMultiple filterFunc decimationD coeffs = do
     evaluate vCoeffs
     let decimateOne   = filterFunc             decimationD vCoeffs
         decimateCross = decimateCrossHighLevel decimationD vCoeffs2
-    return $ Decimator {..}
+    return Decimator {..}
 
 -- | Returns a fast Decimator data structure implemented in C. For decimating complex data with real coefficients.
 fastDecimatorCC :: Int                                                    -- ^ The decimation factor
@@ -367,8 +367,8 @@ mkDecimatorSymR filterFunc decimationD coeffs = do
     let decimateOne   = filterFunc             decimationD vCoeffs
         decimateCross = decimateCrossHighLevel decimationD vCoeffs2
         numCoeffsD    = length coeffs * 2
-    return $ Decimator {..}
     
+    return Decimator {..}
 -- | Returns a fast Decimator data structure implemented in C using SSE instructions. For decimating real data with real coefficients. For decimators with symmetric coefficients, i.e. 'linear phase'. Coefficient length must be a multiple of 4.
 fastDecimatorSymSSER :: Int                                          -- ^ The decimation factor
                      -> [Float]                                      -- ^ The first half of the filter coefficients
@@ -403,7 +403,7 @@ haskellResampler interpolationR decimationR coeffs = do
         numCoeffsR            = length coeffs
         func          x       = (x, x)
         startDat              = 0
-    return $ Resampler {..}
+    return Resampler {..}
 
 mkResampler :: Int
             -> ResampleRR
@@ -422,7 +422,7 @@ mkResampler sizeMultiple filterFunc interpolationR decimationR coeffs = do
         numCoeffsR              = roundUp (length coeffs) (interpolationR * sizeMultiple)
         func1 group             = let offset = interpolationR - 1 - ((interpolationR + group * decimationR - 1) `mod` interpolationR) in ((group, offset), offset)
         startDat                = (0, 0)
-    return $ Resampler {..}
+    return Resampler {..}
 
 mkResamplerC :: Int
              -> ResampleRC
@@ -441,7 +441,7 @@ mkResamplerC sizeMultiple filterFunc interpolationR decimationR coeffs = do
         numCoeffsR              = roundUp (length coeffs) (interpolationR * sizeMultiple)
         func1 group             = let offset = interpolationR - 1 - ((interpolationR + group * decimationR - 1) `mod` interpolationR) in ((group, offset), offset)
         startDat                = (0, 0)
-    return $ Resampler {..}
+    return Resampler {..}
 
 -- | Returns a fast Resampler data structure implemented in C. For filtering real data with real coefficients.
 fastResamplerCR :: Int                                          -- ^ The interpolation factor

--- a/tests/TestSuite.hs
+++ b/tests/TestSuite.hs
@@ -23,11 +23,11 @@ sameResultM _  []     = return True
 sameResultM eq (x:xs) = do
     res  <- x
     ress <- sequence xs
-    return $ and $ map (eq res) ress
+    return $ all (eq res) ress
 
 sameResult :: (a -> a -> Bool) -> [a] -> Bool
 sameResult _ [] = True
-sameResult eq (x:xs) = and $ map (eq x) xs
+sameResult eq (x:xs) = all (eq x) xs
 
 tests info = [
         testGroup "filters" [
@@ -281,10 +281,10 @@ tests info = [
         func outBuf
         out :: VS.Vector a <- VG.freeze outBuf
         return $ VG.toList out
-    eqDelta x y = and $ map (uncurry eqDelta') $ zip x y
+    eqDelta x y = all (uncurry eqDelta') $ zip x y
         where
         eqDelta' x y = abs (x - y) < 0.01
-    eqDeltaC x y = and $ map (uncurry eqDelta') $ zip x y
+    eqDeltaC x y = all (uncurry eqDelta') $ zip x y
         where
         eqDelta' x y = magnitude (x - y) < 0.01
     duplicate :: [a] -> [a]

--- a/tests/TestSuite.hs
+++ b/tests/TestSuite.hs
@@ -71,7 +71,7 @@ tests info = [
             vInput      = VS.fromList inBuf
             num         = size - numCoeffs*2 + 1
 
-        res <- run $ sameResultM eqDelta $ map (getResult num $) $ hasFeatures [
+        res <- run $ sameResultM eqDelta $ map (getResult num) $ hasFeatures [
                 (const True, filterHighLevel       vCoeffs     num vInput),
                 (const True, filterImperative1     vCoeffs     num vInput),
                 (const True, filterImperative2     vCoeffs     num vInput),
@@ -99,7 +99,7 @@ tests info = [
             num         = size - numCoeffs*2 + 1
             vCoeffs2    = VG.fromList $ duplicate $ coeffs ++ reverse coeffs
 
-        res <- run $ sameResultM eqDeltaC $ map (getResult num $) $ hasFeatures [
+        res <- run $ sameResultM eqDeltaC $ map (getResult num) $ hasFeatures [
                 (const True, filterHighLevel       vCoeffs  num vInput),
                 (const True, filterCRC             vCoeffs  num vInput),
                 (hasSSE42,   filterCSSERC          vCoeffs2 num vInput),
@@ -125,7 +125,7 @@ tests info = [
             vInput      = VS.fromList inBuf
             num         = (size - numCoeffs*2 + 1) `quot` factor
 
-        res <- run $ sameResultM eqDelta $ map (getResult num $) $ hasFeatures [
+        res <- run $ sameResultM eqDelta $ map (getResult num) $ hasFeatures [
                 (const True, decimateHighLevel       factor vCoeffs     num vInput),
                 (const True, decimateCRR             factor vCoeffs     num vInput),
                 (hasSSE42,   decimateCSSERR          factor vCoeffs     num vInput),
@@ -152,7 +152,7 @@ tests info = [
             num         = (size - numCoeffs*2 + 1) `quot` factor
             vCoeffs2    = VG.fromList $ duplicate $ coeffs ++ reverse coeffs
 
-        res <- run $ sameResultM eqDeltaC $ map (getResult num $) $ hasFeatures [
+        res <- run $ sameResultM eqDeltaC $ map (getResult num) $ hasFeatures [
                 (const True, decimateHighLevel       factor vCoeffs  num vInput),
                 (const True, decimateCRC             factor vCoeffs  num vInput),
                 (hasSSE42,   decimateCSSERC          factor vCoeffs2 num vInput),
@@ -186,7 +186,7 @@ tests info = [
         resampler4 <- run $ resampleCSSERR interpolation decimation (coeffs ++ reverse coeffs)
         resampler5 <- run $ resampleCAVXRR interpolation decimation (coeffs ++ reverse coeffs)
 
-        res <- run $ sameResultM eqDelta $ map (getResult num $) $ hasFeatures [
+        res <- run $ sameResultM eqDelta $ map (getResult num) $ hasFeatures [
                 (const True, void . resampleHighLevel       interpolation decimation vCoeffs offset num vInput),
                 (const True, void . resampleCRR             num interpolation decimation offset vCoeffs vInput),
                 (const True, void . resampler3              group num vInput),
@@ -218,7 +218,7 @@ tests info = [
         resampler4 <- run $ resampleCSSERC interpolation decimation (coeffs ++ reverse coeffs)
         resampler5 <- run $ resampleCAVXRC interpolation decimation (coeffs ++ reverse coeffs)
 
-        res <- run $ sameResultM eqDeltaC $ map (getResult num $) $ hasFeatures [
+        res <- run $ sameResultM eqDeltaC $ map (getResult num) $ hasFeatures [
                 (const True, void . resampleHighLevel       interpolation decimation vCoeffs offset num vInput),
                 (const True, void . resampler3              group num vInput),
                 (hasSSE42,   void . resampler4              group num vInput),
@@ -234,7 +234,7 @@ tests info = [
     testConversionRTLSDR size inBuf = monadicIO $ do
         let vInput = VS.fromList $ map fromIntegral inBuf
 
-        let res = sameResult eqDeltaC $ map (VG.toList $) $ hasFeatures [
+        let res = sameResult eqDeltaC $ map VG.toList $ hasFeatures [
                 (const True, (interleavedIQUnsigned256ToFloat    vInput :: VS.Vector (Complex Float))),
                 (const True, interleavedIQUnsignedByteToFloat    vInput),
                 (hasSSE42,   interleavedIQUnsignedByteToFloatSSE vInput),
@@ -250,7 +250,7 @@ tests info = [
     testConversionBladeRF size inBuf = monadicIO $ do
         let vInput = VS.fromList $ map fromIntegral inBuf
 
-        let res = sameResult eqDeltaC $ map (VG.toList $) $ hasFeatures [
+        let res = sameResult eqDeltaC $ map VG.toList $ hasFeatures [
                 (const True, (interleavedIQSigned2048ToFloat   vInput :: VS.Vector (Complex Float))),
                 (const True, interleavedIQSignedWordToFloat    vInput),
                 (hasSSE42,   interleavedIQSignedWordToFloatSSE vInput),
@@ -268,7 +268,7 @@ tests info = [
     testScaleReal size inBuf factor = monadicIO $ do
         let vInput = VS.fromList inBuf
 
-        res <- run $ sameResultM eqDelta $ map (getResult size $) $ hasFeatures [
+        res <- run $ sameResultM eqDelta $ map (getResult size) $ hasFeatures [
                 (const True, scaleC    factor vInput),
                 (hasSSE42,   scaleCSSE factor vInput),
                 (hasAVX,     scaleCAVX factor vInput)

--- a/tests/TestSuite.hs
+++ b/tests/TestSuite.hs
@@ -288,7 +288,7 @@ tests info = [
         where
         eqDelta' x y = magnitude (x - y) < 0.01
     duplicate :: [a] -> [a]
-    duplicate = concat . map func 
+    duplicate = concatMap func
         where func x = [x, x]
 
 main = do


### PR DESCRIPTION
Hi,

I fixed some issues reported by `hlint`:
- Remove redundant `$`
- Remove unused `BangPatterns` pragma
- Replace `and $ map f` with `all f`
- Replace `concat . map f` with `concatMap f`

I left them as separate commits, but I can squash them if wanted ;)

-- 24pullrequests
[![](http://24pullrequests.com/assets/logo-8a77737f86fec8def19a1c9a605c9841dbd44e59f243ed3bf64bbdf3214d6fa1.png)](http://24pullrequests.com/)
